### PR TITLE
Add missed Term import in spans.py

### DIFF
--- a/src/whoosh/query/spans.py
+++ b/src/whoosh/query/spans.py
@@ -44,6 +44,7 @@ For example, to find documents containing "whoosh" at most 5 positions before
 """
 
 from whoosh.matching import binary, mcore, wrappers
+from whoosh.query import Term
 from whoosh.query.compound import And, AndMaybe, Or
 from whoosh.query.qcore import Query
 from whoosh.util import make_binary_tree


### PR DESCRIPTION
This pull request adds the missed import statement for the `Term` class in the `spans.py` file. This import is necessary for the code to function correctly.