### PR TITLE
Fix: Resolve the Codecov reporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,9 +31,13 @@ jobs:
         pip install -e .
     - name: Run tests
       run: |
-        pip install pytest
-        pip install pytest-cov
-        pytest --cov=./ --cov-report=xml
+        pytest --cov=./ --cov-report=xml --cov-report=html
+    - name: Upload HTML coverage report
+      uses: actions/upload-artifact@v4
+      with:
+        name: "HTML Coverage ${{ matrix.python-version }}"
+        path: "htmlcov"
+        retention-days: 7
 
     - name: Upload Coverage to Codecov
       uses: codecov/codecov-action@v4.0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,12 +25,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        pip install pytest pytest-cov coverage cached-property
-          python setup.py clean build install
-    - name: Run test
-      run: pytest
-
-    - name: Generate coverage report
+        pip install pytest pytest-cov pytest-sugar coverage cached-property
+    - name: Install Whoosh
+      run: |
+        pip install -e .
+    - name: Run tests
       run: |
         pip install pytest
         pip install pytest-cov


### PR DESCRIPTION
# Description

This resolves the code coverage reporting, so the actual source files will also have coverage reported.  I configured my own fork with a token and you can view the results: https://app.codecov.io/github/stumpylog/whoosh-reloaded

The main fix is to install using `pip install -e .` or editable.  Otherwise, coverage was not picked up those files are being relvant.

The other small fix was to only run the testing once.

Closes: #48

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
