### PR TITLE
Bump whoosh-reloaded version to 3.0.0

### DIFF
--- a/src/whoosh/__init__.py
+++ b/src/whoosh/__init__.py
@@ -25,7 +25,7 @@
 # those of the authors and should not be interpreted as representing official
 # policies, either expressed or implied, of Matt Chaput.
 
-__version__ = (2, 7, 5)
+__version__ = (3, 0, 0)
 
 
 def versionstring(build=True, extra=True):


### PR DESCRIPTION
This pull request updates the whoosh-reloaded version to 3.0.0. This update includes various improvements and bug fixes.