### PR TITLE
MultiFilter raises StopIteration

### DIFF
--- a/src/whoosh/analysis/filters.py
+++ b/src/whoosh/analysis/filters.py
@@ -176,9 +176,11 @@ class MultiFilter(Filter):
 
     def __call__(self, tokens):
         # Only selects on the first token
-        t = next(tokens)
-        selected_filter = self.filters.get(t.mode, self.default_filter)
-        return selected_filter(chain([t], tokens))
+        t = next(tokens, None)
+        if t is not None:
+            selected_filter = self.filters.get(t.mode, self.default_filter)
+            return selected_filter(chain([t], tokens))
+        return []
 
 
 class TeeFilter(Filter):


### PR DESCRIPTION
MultiFilter raises `StopIteration` if there are no tokens to filter. Added a check for this case and returned an empty token list.

# Description

* relevant motivation: I ran into this error when parsing queries (that should've been null queries) with a custom tokeniser.
* a summary of the change: See above.
* which issue is fixed: N/A
* any additional dependencies that are required for this change: N/A


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
