### PR TITLE
Enhancement: add support 'last year' and 'last month' dateparsing

### DIFF
--- a/docs/source/dates.rst
+++ b/docs/source/dates.rst
@@ -67,6 +67,7 @@ With the ``DateParserPlugin``, users can use date queries such as::
     -1 week to now
     now to +2h
     -1y6mo to +2 yrs 23d
+    last year
 
 Normally, as with other types of queries containing spaces, the users need
 to quote date queries containing spaces using single quotes::

--- a/src/whoosh/qparser/dateparse.py
+++ b/src/whoosh/qparser/dateparse.py
@@ -729,6 +729,12 @@ class English(DateParser):
         thismonth = Regex(
             "this month", lambda p, dt: adatetime(year=dt.year, month=dt.month)
         )
+
+        lastyear = Regex("last year", lambda p, dt: adatetime(year=dt.year - 1))
+        lastmonth = Regex(
+            "last month", lambda p, dt: adatetime(year=dt.year, month=dt.month - 1)
+        )
+
         today = Regex(
             "today", lambda p, dt: adatetime(year=dt.year, month=dt.month, day=dt.day)
         )
@@ -767,6 +773,8 @@ class English(DateParser):
                 yesterday,
                 thisyear,
                 thismonth,
+                lastyear,
+                lastmonth,
                 today,
                 now,
             ),

--- a/tests/test_dateparse.py
+++ b/tests/test_dateparse.py
@@ -146,6 +146,8 @@ def test_dmy(d=english.dmy):
     assert_adatetime(d.date_from("yesterday", basedate), year=2010, month=9, day=19)
     assert_adatetime(d.date_from("this month", basedate), year=2010, month=9)
     assert_adatetime(d.date_from("this year", basedate), year=2010)
+    assert_adatetime(d.date_from("last month", basedate), year=2010, month=8)
+    assert_adatetime(d.date_from("last year", basedate), year=2009)
 
     assert d.date_from("now", basedate) == basedate
 


### PR DESCRIPTION
# Description

Does what it says on the tin! It took a little debugging for me to realize this isnt currently supported, it seems logical given there other supported strings.

Happy to see the project moving forward!

Closes: # (issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] ~~I have commented my code in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
