### PR TITLE
perf: add Bloom Filter for negative term lookups

### DIFF
--- a/src/whoosh/codec/whoosh3.py
+++ b/src/whoosh/codec/whoosh3.py
@@ -39,6 +39,7 @@ from whoosh.codec import base
 from whoosh.filedb import compound, filetables
 from whoosh.matching import LeafMatcher, ListMatcher, ReadTooFar
 from whoosh.reading import TermInfo, TermNotFound
+from whoosh.support.bloom import BloomFilter
 from whoosh.system import (
     _FLOAT_SIZE,
     _INT_SIZE,
@@ -81,11 +82,15 @@ class W3Codec(base.Codec):
     POSTS_EXT = ".pst"  # Term postings
     VPOSTS_EXT = ".vps"  # Vector postings
     COLUMN_EXT = ".col"  # Per-document value columns
+    BLOOM_EXT = ".blm"  # Bloom filter for negative term lookups
 
-    def __init__(self, blocklimit=128, compression=3, inlinelimit=1):
+    def __init__(self, blocklimit=128, compression=3, inlinelimit=1,
+                 bloom_enabled=True, bloom_false_positive_rate=0.01):
         self._blocklimit = blocklimit
         self._compression = compression
         self._inlinelimit = inlinelimit
+        self._bloom_enabled = bloom_enabled
+        self._bloom_fpr = bloom_false_positive_rate
 
     # def automata(self):
 
@@ -139,7 +144,24 @@ class W3Codec(base.Codec):
 
         postfile = segment.open_file(storage, self.POSTS_EXT)
 
-        return W3TermsReader(self, tifile, tilen, postfile)
+        # Load Bloom filter if available
+        bloom = None
+        if self._bloom_enabled:
+            blmname = segment.make_filename(self.BLOOM_EXT)
+            try:
+                if storage.file_exists(blmname):
+                    blmlen = storage.file_length(blmname)
+                    blmfile = storage.open_file(blmname)
+                    try:
+                        bloom_data = blmfile.read(blmlen)
+                        bloom = BloomFilter.from_bytes(bloom_data)
+                    finally:
+                        blmfile.close()
+            except Exception:
+                # If the Bloom filter can't be loaded, we just skip it
+                bloom = None
+
+        return W3TermsReader(self, tifile, tilen, postfile, bloom=bloom)
 
     # Graph methods provided by CodecWithGraph
 
@@ -320,6 +342,12 @@ class W3FieldWriter(base.FieldWriter):
         self._infield = False
         self.is_closed = False
 
+        # Bloom filter tracking: collect all term keys during writing
+        self._bloom_enabled = codec._bloom_enabled
+        self._bloom_fpr = codec._bloom_fpr
+        self._bloom_keys = [] if self._bloom_enabled else None
+        self._bloom_term_count = 0
+
     def _create_file(self, ext):
         return self._segment.create_file(self._storage, ext)
 
@@ -356,6 +384,11 @@ class W3FieldWriter(base.FieldWriter):
         valbytes = terminfo.to_bytes()
         self._tindex.add(keybytes, valbytes)
 
+        # Track key for Bloom filter
+        if self._bloom_keys is not None:
+            self._bloom_keys.append(keybytes)
+            self._bloom_term_count += 1
+
     # FieldWriterWithGraph.add_spell_word
 
     def finish_field(self):
@@ -367,6 +400,20 @@ class W3FieldWriter(base.FieldWriter):
     def close(self):
         self._tindex.close()
         self._postfile.close()
+
+        # Write Bloom filter file
+        if self._bloom_keys is not None and self._bloom_term_count > 0:
+            bloom = BloomFilter(
+                expected_items=self._bloom_term_count,
+                false_positive_rate=self._bloom_fpr,
+            )
+            for key in self._bloom_keys:
+                bloom.add(key)
+            blmfile = self._segment.create_file(self._storage, W3Codec.BLOOM_EXT)
+            bloom.write_to_file(blmfile)
+            blmfile.close()
+            self._bloom_keys = None
+
         self.is_closed = True
 
 
@@ -579,12 +626,13 @@ class W3FieldCursor(base.FieldCursor):
 
 
 class W3TermsReader(base.TermsReader):
-    def __init__(self, codec, dbfile, length, postfile):
+    def __init__(self, codec, dbfile, length, postfile, bloom=None):
         self._codec = codec
         self._dbfile = dbfile
         self._tindex = filetables.OrderedHashReader(dbfile, length)
         self._fieldmap = self._tindex.extras["fieldmap"]
         self._postfile = postfile
+        self._bloom = bloom
 
         self._fieldunmap = [None] * len(self._fieldmap)
         for fieldname, num in self._fieldmap.items():
@@ -603,7 +651,12 @@ class W3TermsReader(base.TermsReader):
         return self._tindex.range_for_key(self._keycoder(fieldname, tbytes))
 
     def __contains__(self, term):
-        return self._keycoder(*term) in self._tindex
+        key = self._keycoder(*term)
+        # Fast rejection via Bloom filter: if the key is definitely not in
+        # the filter, skip the expensive on-disk hash table lookup
+        if self._bloom is not None and key not in self._bloom:
+            return False
+        return key in self._tindex
 
     def indexed_field_names(self):
         return self._fieldmap.keys()
@@ -644,20 +697,34 @@ class W3TermsReader(base.TermsReader):
 
     def term_info(self, fieldname, tbytes):
         key = self._keycoder(fieldname, tbytes)
+        # Bloom filter short-circuit: avoid disk read for absent terms
+        if self._bloom is not None and key not in self._bloom:
+            raise TermNotFound(f"No term {fieldname}:{tbytes!r}")
         try:
             return W3TermInfo.from_bytes(self._tindex[key])
         except KeyError:
             raise TermNotFound(f"No term {fieldname}:{tbytes!r}")
 
     def frequency(self, fieldname, tbytes):
+        # Bloom filter short-circuit for frequency lookups
+        if self._bloom is not None:
+            key = self._keycoder(fieldname, tbytes)
+            if key not in self._bloom:
+                return 0
         datapos = self._range_for_key(fieldname, tbytes)[0]
         return W3TermInfo.read_weight(self._dbfile, datapos)
 
     def doc_frequency(self, fieldname, tbytes):
+        # Bloom filter short-circuit for doc_frequency lookups
+        if self._bloom is not None:
+            key = self._keycoder(fieldname, tbytes)
+            if key not in self._bloom:
+                return 0
         datapos = self._range_for_key(fieldname, tbytes)[0]
         return W3TermInfo.read_doc_freq(self._dbfile, datapos)
 
     def matcher(self, fieldname, tbytes, format_, scorer=None):
+        # term_info already uses the Bloom filter, so no extra check needed
         terminfo = self.term_info(fieldname, tbytes)
         m = self._codec.postings_reader(
             self._postfile, terminfo, format_, term=(fieldname, tbytes), scorer=scorer

--- a/src/whoosh/idsets.py
+++ b/src/whoosh/idsets.py
@@ -1,5 +1,34 @@
-"""
-An implementation of an object that acts like a collection of on/off bits.
+# Copyright 2010 Matt Chaput. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    1. Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#
+#    2. Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY MATT CHAPUT ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+# EVENT SHALL MATT CHAPUT OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+# EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# The views and conclusions contained in the software and documentation are
+# those of the authors and should not be interpreted as representing official
+# policies, either expressed or implied, of Matt Chaput.
+
+"""Set-like containers specialised for storing sorted collections of document
+IDs.  Includes :class:`BitSet` (bit-array backed), :class:`SortedIntSet`
+(sorted-array backed), :class:`OnDiskBitSet` (memory-mapped), and
+:class:`RoaringIdSet` (hybrid roaring-bitmap style).
 """
 
 import operator
@@ -9,268 +38,8 @@ from itertools import zip_longest
 
 from whoosh.util.numeric import bytes_for_bits
 
-# Number of '1' bits in each byte (0-255)
-_1SPERBYTE = array(
-    "B",
-    [
-        0,
-        1,
-        1,
-        2,
-        1,
-        2,
-        2,
-        3,
-        1,
-        2,
-        2,
-        3,
-        2,
-        3,
-        3,
-        4,
-        1,
-        2,
-        2,
-        3,
-        2,
-        3,
-        3,
-        4,
-        2,
-        3,
-        3,
-        4,
-        3,
-        4,
-        4,
-        5,
-        1,
-        2,
-        2,
-        3,
-        2,
-        3,
-        3,
-        4,
-        2,
-        3,
-        3,
-        4,
-        3,
-        4,
-        4,
-        5,
-        2,
-        3,
-        3,
-        4,
-        3,
-        4,
-        4,
-        5,
-        3,
-        4,
-        4,
-        5,
-        4,
-        5,
-        5,
-        6,
-        1,
-        2,
-        2,
-        3,
-        2,
-        3,
-        3,
-        4,
-        2,
-        3,
-        3,
-        4,
-        3,
-        4,
-        4,
-        5,
-        2,
-        3,
-        3,
-        4,
-        3,
-        4,
-        4,
-        5,
-        3,
-        4,
-        4,
-        5,
-        4,
-        5,
-        5,
-        6,
-        2,
-        3,
-        3,
-        4,
-        3,
-        4,
-        4,
-        5,
-        3,
-        4,
-        4,
-        5,
-        4,
-        5,
-        5,
-        6,
-        3,
-        4,
-        4,
-        5,
-        4,
-        5,
-        5,
-        6,
-        4,
-        5,
-        5,
-        6,
-        5,
-        6,
-        6,
-        7,
-        1,
-        2,
-        2,
-        3,
-        2,
-        3,
-        3,
-        4,
-        2,
-        3,
-        3,
-        4,
-        3,
-        4,
-        4,
-        5,
-        2,
-        3,
-        3,
-        4,
-        3,
-        4,
-        4,
-        5,
-        3,
-        4,
-        4,
-        5,
-        4,
-        5,
-        5,
-        6,
-        2,
-        3,
-        3,
-        4,
-        3,
-        4,
-        4,
-        5,
-        3,
-        4,
-        4,
-        5,
-        4,
-        5,
-        5,
-        6,
-        3,
-        4,
-        4,
-        5,
-        4,
-        5,
-        5,
-        6,
-        4,
-        5,
-        5,
-        6,
-        5,
-        6,
-        6,
-        7,
-        2,
-        3,
-        3,
-        4,
-        3,
-        4,
-        4,
-        5,
-        3,
-        4,
-        4,
-        5,
-        4,
-        5,
-        5,
-        6,
-        3,
-        4,
-        4,
-        5,
-        4,
-        5,
-        5,
-        6,
-        4,
-        5,
-        5,
-        6,
-        5,
-        6,
-        6,
-        7,
-        3,
-        4,
-        4,
-        5,
-        4,
-        5,
-        5,
-        6,
-        4,
-        5,
-        5,
-        6,
-        5,
-        6,
-        6,
-        7,
-        4,
-        5,
-        5,
-        6,
-        5,
-        6,
-        6,
-        7,
-        5,
-        6,
-        6,
-        7,
-        6,
-        7,
-        7,
-        8,
-    ],
-)
+#: Popcount lookup table: number of set bits in each byte value (0-255).
+_1SPERBYTE = array("B", [bin(i).count("1") for i in range(256)])
 
 
 class DocIdSet:
@@ -289,8 +58,11 @@ class DocIdSet:
                 return False
         return True
 
-    def __neq__(self, other):
+    def __ne__(self, other):
         return not self.__eq__(other)
+
+    def __hash__(self):
+        raise TypeError(f"unhashable type: '{type(self).__name__}'")
 
     def __len__(self):
         raise NotImplementedError
@@ -417,7 +189,7 @@ class BaseBitSet(DocIdSet):
             base += 8
 
     def __nonzero__(self):
-        return any(n for n in self._iter_bytes())
+        return any(self._iter_bytes())
 
     __bool__ = __nonzero__
 
@@ -514,11 +286,9 @@ class OnDiskBitSet(BaseBitSet):
         self._bytecount = bytecount
 
     def __repr__(self):
-        return "%s(%s, %d, %d)" % (
-            self.__class__.__name__,
-            self.dbfile,
-            self._basepos,
-            self.bytecount,
+        return (
+            f"{self.__class__.__name__}"
+            f"({self._dbfile!r}, {self._basepos}, {self._bytecount})"
         )
 
     def byte_count(self):
@@ -542,10 +312,10 @@ class BitSet(BaseBitSet):
 
     def __init__(self, source=None, size=0):
         """
-        :param maxsize: the maximum size of the bit array.
         :param source: an iterable of positive integers to add to this set.
-        :param bits: an array of unsigned bytes ("B") to use as the underlying
-            bit array. This is used by some of the object's methods.
+        :param size: initial size hint (in bits) for the underlying array.
+            When *source* is a list, tuple, set, or frozenset the size is
+            inferred automatically.
         """
 
         # If the source is a list, tuple, or set, we can guess the size
@@ -883,14 +653,14 @@ class RoaringIdSet(DocIdSet):
         return (n - (bucket << 16)) in self.idsets[bucket]
 
     def __iter__(self):
-        for i, idset in self.idsets:
+        for i, idset in enumerate(self.idsets):
             floor = i << 16
             for n in idset:
                 yield floor + n
 
     def _find(self, n):
         bucket = n >> 16
-        floor = n << 16
+        floor = bucket << 16
         if bucket >= len(self.idsets):
             self.idsets.extend(
                 [SortedIntSet() for _ in range(len(self.idsets), bucket + 1)]

--- a/src/whoosh/support/bitvector.py
+++ b/src/whoosh/support/bitvector.py
@@ -1,277 +1,47 @@
-"""
-An implementation of an object that acts like a collection of on/off bits.
+# Copyright 2010 Matt Chaput. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    1. Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#
+#    2. Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY MATT CHAPUT ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+# EVENT SHALL MATT CHAPUT OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+# EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# The views and conclusions contained in the software and documentation are
+# those of the authors and should not be interpreted as representing official
+# policies, either expressed or implied, of Matt Chaput.
+
+"""Legacy bit-array and dynamic set implementations.
+
+This module provides :class:`BitVector`, a fixed-size array of bits with
+set-like operations, and :class:`BitSet`, a hybrid container that
+automatically switches its backing store between a ``set`` and a
+:class:`BitVector` depending on density.
 """
 
 import operator
 from array import array
 
-#: Table of the number of '1' bits in each byte (0-255)
-BYTE_COUNTS = array(
-    "B",
-    [
-        0,
-        1,
-        1,
-        2,
-        1,
-        2,
-        2,
-        3,
-        1,
-        2,
-        2,
-        3,
-        2,
-        3,
-        3,
-        4,
-        1,
-        2,
-        2,
-        3,
-        2,
-        3,
-        3,
-        4,
-        2,
-        3,
-        3,
-        4,
-        3,
-        4,
-        4,
-        5,
-        1,
-        2,
-        2,
-        3,
-        2,
-        3,
-        3,
-        4,
-        2,
-        3,
-        3,
-        4,
-        3,
-        4,
-        4,
-        5,
-        2,
-        3,
-        3,
-        4,
-        3,
-        4,
-        4,
-        5,
-        3,
-        4,
-        4,
-        5,
-        4,
-        5,
-        5,
-        6,
-        1,
-        2,
-        2,
-        3,
-        2,
-        3,
-        3,
-        4,
-        2,
-        3,
-        3,
-        4,
-        3,
-        4,
-        4,
-        5,
-        2,
-        3,
-        3,
-        4,
-        3,
-        4,
-        4,
-        5,
-        3,
-        4,
-        4,
-        5,
-        4,
-        5,
-        5,
-        6,
-        2,
-        3,
-        3,
-        4,
-        3,
-        4,
-        4,
-        5,
-        3,
-        4,
-        4,
-        5,
-        4,
-        5,
-        5,
-        6,
-        3,
-        4,
-        4,
-        5,
-        4,
-        5,
-        5,
-        6,
-        4,
-        5,
-        5,
-        6,
-        5,
-        6,
-        6,
-        7,
-        1,
-        2,
-        2,
-        3,
-        2,
-        3,
-        3,
-        4,
-        2,
-        3,
-        3,
-        4,
-        3,
-        4,
-        4,
-        5,
-        2,
-        3,
-        3,
-        4,
-        3,
-        4,
-        4,
-        5,
-        3,
-        4,
-        4,
-        5,
-        4,
-        5,
-        5,
-        6,
-        2,
-        3,
-        3,
-        4,
-        3,
-        4,
-        4,
-        5,
-        3,
-        4,
-        4,
-        5,
-        4,
-        5,
-        5,
-        6,
-        3,
-        4,
-        4,
-        5,
-        4,
-        5,
-        5,
-        6,
-        4,
-        5,
-        5,
-        6,
-        5,
-        6,
-        6,
-        7,
-        2,
-        3,
-        3,
-        4,
-        3,
-        4,
-        4,
-        5,
-        3,
-        4,
-        4,
-        5,
-        4,
-        5,
-        5,
-        6,
-        3,
-        4,
-        4,
-        5,
-        4,
-        5,
-        5,
-        6,
-        4,
-        5,
-        5,
-        6,
-        5,
-        6,
-        6,
-        7,
-        3,
-        4,
-        4,
-        5,
-        4,
-        5,
-        5,
-        6,
-        4,
-        5,
-        5,
-        6,
-        5,
-        6,
-        6,
-        7,
-        4,
-        5,
-        5,
-        6,
-        5,
-        6,
-        6,
-        7,
-        5,
-        6,
-        6,
-        7,
-        6,
-        7,
-        7,
-        8,
-    ],
-)
+#: Popcount lookup table: number of set bits in each byte value (0-255).
+BYTE_COUNTS = array("B", [bin(i).count("1") for i in range(256)])
 
 
 class BitVector:
-    """
-    Implements a memory-efficient array of bits.
+    """Implements a memory-efficient fixed-size array of bits.
 
     >>> bv = BitVector(10)
     >>> bv
@@ -280,25 +50,26 @@ class BitVector:
     >>> bv
     <BitVector 0000010000>
 
-    You can initialize the BitVector using an iterable of integers representing bit
-    positions to turn on.
+    You can initialise a ``BitVector`` using an iterable of integers
+    representing bit positions to turn on.
 
     >>> bv2 = BitVector(10, [2, 4, 7])
     >>> bv2
-    <BitVector 00101001000>
-    >>> bv[2]
+    <BitVector 0010100100>
+    >>> bv2[2]
     True
 
-    BitVector supports bit-wise logic operations & (and), | (or), and ^ (xor)
-    between itself and another BitVector of equal size, or itself and a collection of
-    integers (usually a set() or frozenset()).
+    ``BitVector`` supports bit-wise logic operations ``&`` (and), ``|`` (or),
+    and ``^`` (xor) between itself and another ``BitVector`` of equal size, or
+    itself and a collection of integers (usually a ``set`` or ``frozenset``).
 
     >>> bv | bv2
-    <BitVector 00101101000>
+    <BitVector 0010110100>
 
     Note that ``BitVector.__len__()`` returns the number of "on" bits, not
-    the size of the bit array. This is to make BitVector interchangeable with
-    a set()/frozenset() of integers. To get the size, use BitVector.size.
+    the size of the bit array.  This is to make ``BitVector`` interchangeable
+    with a ``set``/``frozenset`` of integers.  To get the size, use
+    ``BitVector.size``.
     """
 
     def __init__(self, size, source=None, bits=None):
@@ -310,9 +81,9 @@ class BitVector:
             self.bits = array("B", ([0x00] * ((size >> 3) + 1)))
 
         if source:
-            set = self.set
+            _set = self.set
             for num in source:
-                set(num)
+                _set(num)
 
         self.bcount = None
 
@@ -422,20 +193,20 @@ class BitVector:
         on the bits at those positions.
         """
 
-        set = self.set
+        _set = self.set
         for index in iterable:
-            set(index)
+            _set(index)
 
     def copy(self):
-        """Returns a copy of this BitArray."""
+        """Returns a copy of this BitVector."""
 
         return BitVector(self.size, bits=self.bits)
 
 
 class BitSet:
-    """A set-like object for holding positive integers. It is dynamically
-    backed by either a set or BitVector depending on how many numbers are in
-    the set.
+    """A set-like object for holding positive integers.  It is dynamically
+    backed by either a ``set`` or :class:`BitVector` depending on how many
+    numbers are in the set.
 
     Provides ``add``, ``remove``, ``union``, ``intersection``,
     ``__contains__``, ``__len__``, ``__iter__``, ``__and__``, ``__or__``, and
@@ -459,7 +230,7 @@ class BitSet:
             self.add = self._set_add
             self.remove = self._back.remove
         else:
-            self._back = BitVector()
+            self._back = BitVector(self.size)
             self.add = self._back.set
             self.remove = self._vec_remove
 

--- a/src/whoosh/support/bloom.py
+++ b/src/whoosh/support/bloom.py
@@ -1,0 +1,310 @@
+# Copyright 2026 Whoosh Reloaded contributors. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    1. Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#
+#    2. Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+# FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+
+"""
+Bloom Filter implementation for fast negative lookups.
+
+A Bloom filter is a probabilistic data structure that can definitively say
+when an element is NOT in a set (no false negatives) but may occasionally
+report an element as present when it is not (false positives). This makes
+it ideal for avoiding expensive disk reads when looking up terms that do
+not exist in the index.
+
+Usage::
+
+    from whoosh.support.bloom import BloomFilter
+
+    # Create a Bloom filter sized for expected number of items
+    bf = BloomFilter(expected_items=10000, false_positive_rate=0.01)
+
+    # Add items
+    bf.add(b"hello")
+    bf.add(b"world")
+
+    # Test membership (fast, in-memory)
+    assert b"hello" in bf       # True (definitely present)
+    assert b"missing" not in bf  # True (definitely absent)
+
+    # Serialize / deserialize
+    data = bf.to_bytes()
+    bf2 = BloomFilter.from_bytes(data)
+"""
+
+import math
+import struct
+from array import array
+from hashlib import md5, sha256
+
+# Header format: magic(4) + version(1) + num_hashes(1) + size_bytes(4) + num_bits(4)
+_BLOOM_HEADER = struct.Struct("!4sBBII")
+_BLOOM_MAGIC = b"BLM1"
+_BLOOM_VERSION = 1
+
+
+def _optimal_num_bits(n, p):
+    """Calculate the optimal number of bits for a Bloom filter.
+
+    :param n: expected number of items.
+    :param p: desired false positive rate (0 < p < 1).
+    :returns: number of bits (m).
+    """
+    if n <= 0:
+        return 64  # minimum sensible size
+    if p <= 0 or p >= 1:
+        p = 0.01
+    m = -1.0 * (n * math.log(p)) / (math.log(2) ** 2)
+    return max(64, int(math.ceil(m)))
+
+
+def _optimal_num_hashes(m, n):
+    """Calculate the optimal number of hash functions.
+
+    :param m: number of bits in the filter.
+    :param n: expected number of items.
+    :returns: number of hash functions (k).
+    """
+    if n <= 0:
+        return 1
+    k = (m / n) * math.log(2)
+    return max(1, min(int(math.ceil(k)), 16))
+
+
+def _hash_key(key, seed):
+    """Generate a deterministic hash position for the given key and seed.
+
+    Uses a double-hashing scheme based on MD5 and SHA-256 to produce
+    multiple independent hash values from two base hashes.
+
+    :param key: bytes to hash.
+    :param seed: integer seed (0-based index of the hash function).
+    :returns: non-negative integer hash value.
+    """
+    # Double hashing: h(i) = h1 + i * h2
+    # This gives us k independent hash functions from just two base hashes
+    if not isinstance(key, bytes):
+        key = key.encode("utf-8")
+    h1 = int.from_bytes(md5(key).digest()[:8], "big")
+    h2 = int.from_bytes(sha256(key).digest()[:8], "big")
+    return h1 + seed * h2
+
+
+class BloomFilter:
+    """A space-efficient probabilistic data structure for set membership testing.
+
+    The Bloom filter guarantees no false negatives: if ``__contains__`` returns
+    ``False``, the element is definitely not in the set. It may return
+    ``True`` for elements that were never added (false positives), with a
+    probability controlled by the ``false_positive_rate`` parameter.
+
+    This implementation uses a double-hashing scheme for generating multiple
+    hash functions from two base hash computations, keeping CPU cost low.
+    """
+
+    __slots__ = ("_bits", "_num_bits", "_num_hashes", "_count")
+
+    def __init__(self, expected_items=1000, false_positive_rate=0.01,
+                 num_bits=None, num_hashes=None):
+        """Create a new Bloom filter.
+
+        :param expected_items: estimated number of items to be added.
+        :param false_positive_rate: desired false positive probability (0..1).
+        :param num_bits: override the number of bits (for deserialization).
+        :param num_hashes: override the number of hash functions.
+        """
+        if num_bits is not None and num_hashes is not None:
+            # Direct construction (used by from_bytes)
+            self._num_bits = num_bits
+            self._num_hashes = num_hashes
+        else:
+            self._num_bits = _optimal_num_bits(expected_items, false_positive_rate)
+            self._num_hashes = _optimal_num_hashes(self._num_bits, expected_items)
+
+        # Use a bytearray as the backing store for the bit array
+        num_bytes = (self._num_bits + 7) // 8
+        self._bits = bytearray(num_bytes)
+        self._count = 0
+
+    @property
+    def num_bits(self):
+        """The number of bits in the filter."""
+        return self._num_bits
+
+    @property
+    def num_hashes(self):
+        """The number of hash functions used."""
+        return self._num_hashes
+
+    @property
+    def count(self):
+        """The number of items added (approximate, counting duplicates)."""
+        return self._count
+
+    @property
+    def size_bytes(self):
+        """The memory footprint of the bit array in bytes."""
+        return len(self._bits)
+
+    def estimated_false_positive_rate(self):
+        """Estimate the current false positive rate based on items added.
+
+        :returns: estimated false positive probability.
+        """
+        if self._count == 0:
+            return 0.0
+        # p = (1 - e^(-kn/m))^k
+        exponent = -self._num_hashes * self._count / self._num_bits
+        return (1.0 - math.exp(exponent)) ** self._num_hashes
+
+    def add(self, key):
+        """Add a key to the Bloom filter.
+
+        :param key: bytes or string to add.
+        """
+        if not isinstance(key, bytes):
+            key = key.encode("utf-8")
+
+        bits = self._bits
+        num_bits = self._num_bits
+        for i in range(self._num_hashes):
+            pos = _hash_key(key, i) % num_bits
+            byte_idx = pos >> 3
+            bit_mask = 1 << (pos & 7)
+            bits[byte_idx] |= bit_mask
+        self._count += 1
+
+    def __contains__(self, key):
+        """Test if a key might be in the set.
+
+        :param key: bytes or string to test.
+        :returns: True if possibly present, False if definitely absent.
+        """
+        if not isinstance(key, bytes):
+            key = key.encode("utf-8")
+
+        bits = self._bits
+        num_bits = self._num_bits
+        for i in range(self._num_hashes):
+            pos = _hash_key(key, i) % num_bits
+            byte_idx = pos >> 3
+            bit_mask = 1 << (pos & 7)
+            if not (bits[byte_idx] & bit_mask):
+                return False
+        return True
+
+    def to_bytes(self):
+        """Serialize the Bloom filter to bytes.
+
+        :returns: bytes representation of the filter.
+        """
+        header = _BLOOM_HEADER.pack(
+            _BLOOM_MAGIC,
+            _BLOOM_VERSION,
+            self._num_hashes,
+            len(self._bits),
+            self._num_bits,
+        )
+        return header + bytes(self._bits)
+
+    @classmethod
+    def from_bytes(cls, data):
+        """Deserialize a Bloom filter from bytes.
+
+        :param data: bytes previously produced by ``to_bytes()``.
+        :returns: a new BloomFilter instance.
+        :raises ValueError: if the data is corrupt or has wrong magic.
+        """
+        hdr_size = _BLOOM_HEADER.size
+        if len(data) < hdr_size:
+            raise ValueError("Bloom filter data too short")
+
+        magic, version, num_hashes, size_bytes, num_bits = _BLOOM_HEADER.unpack(
+            data[:hdr_size]
+        )
+        if magic != _BLOOM_MAGIC:
+            raise ValueError(f"Invalid Bloom filter magic: {magic!r}")
+        if version != _BLOOM_VERSION:
+            raise ValueError(f"Unsupported Bloom filter version: {version}")
+
+        expected_size = hdr_size + size_bytes
+        if len(data) < expected_size:
+            raise ValueError(
+                f"Bloom filter data truncated: expected {expected_size}, "
+                f"got {len(data)}"
+            )
+
+        bf = cls.__new__(cls)
+        bf._num_bits = num_bits
+        bf._num_hashes = num_hashes
+        bf._bits = bytearray(data[hdr_size:hdr_size + size_bytes])
+        bf._count = -1  # Unknown when deserialized
+        return bf
+
+    def write_to_file(self, dbfile):
+        """Write the Bloom filter to an open file-like object.
+
+        :param dbfile: a file-like object with a ``write()`` method.
+        """
+        dbfile.write(self.to_bytes())
+
+    @classmethod
+    def read_from_file(cls, dbfile, length=None):
+        """Read a Bloom filter from an open file-like object.
+
+        :param dbfile: a file-like object with ``read()`` method.
+        :param length: optional total length to read; if None, reads header
+            first to determine size.
+        :returns: a new BloomFilter instance.
+        """
+        if length is not None:
+            data = dbfile.read(length)
+        else:
+            # Read header first to get size
+            hdr_data = dbfile.read(_BLOOM_HEADER.size)
+            if len(hdr_data) < _BLOOM_HEADER.size:
+                raise ValueError("Bloom filter data too short")
+            _, _, _, size_bytes, _ = _BLOOM_HEADER.unpack(hdr_data)
+            bit_data = dbfile.read(size_bytes)
+            data = hdr_data + bit_data
+        return cls.from_bytes(data)
+
+    def merge(self, other):
+        """Merge another Bloom filter into this one (OR operation).
+
+        Both filters must have the same parameters (num_bits, num_hashes).
+
+        :param other: another BloomFilter with identical parameters.
+        :raises ValueError: if parameters don't match.
+        """
+        if self._num_bits != other._num_bits:
+            raise ValueError(
+                f"Cannot merge: num_bits differ "
+                f"({self._num_bits} vs {other._num_bits})"
+            )
+        if self._num_hashes != other._num_hashes:
+            raise ValueError(
+                f"Cannot merge: num_hashes differ "
+                f"({self._num_hashes} vs {other._num_hashes})"
+            )
+        for i in range(len(self._bits)):
+            self._bits[i] |= other._bits[i]
+
+    def __repr__(self):
+        return (
+            f"BloomFilter(num_bits={self._num_bits}, "
+            f"num_hashes={self._num_hashes}, "
+            f"size_bytes={self.size_bytes}, "
+            f"count={self._count})"
+        )

--- a/tests/test_bloom.py
+++ b/tests/test_bloom.py
@@ -272,7 +272,7 @@ class TestBloomCodecIntegration:
         tw = codec.field_writer(st, seg)
         tw.start_field("content", fieldobj)
         for i in range(100):
-            tw.start_term(f"term{i}".encode())
+            tw.start_term(f"term{i:03d}".encode())
             tw.add(i, 1.0, b"", 3)
             tw.finish_term()
         tw.finish_field()
@@ -281,11 +281,11 @@ class TestBloomCodecIntegration:
         tr = codec.terms_reader(st, seg)
         # Existing terms should be found
         for i in range(100):
-            assert ("content", f"term{i}".encode()) in tr
+            assert ("content", f"term{i:03d}".encode()) in tr
 
         # Non-existing terms should NOT be found (no false negatives)
         for i in range(100, 200):
-            assert ("content", f"term{i}".encode()) not in tr
+            assert ("content", f"term{i:03d}".encode()) not in tr
 
         tr.close()
 

--- a/tests/test_bloom.py
+++ b/tests/test_bloom.py
@@ -1,0 +1,539 @@
+"""Tests for Bloom filter integration in Whoosh.
+
+Tests cover:
+1. BloomFilter standalone functionality (add, contains, serialize, merge)
+2. Integration with W3Codec writer/reader (negative term lookup optimization)
+3. End-to-end indexing and searching with Bloom filters enabled/disabled
+4. Backward compatibility (indexes without Bloom files)
+"""
+
+import math
+
+import pytest
+
+from whoosh import fields, index, query
+from whoosh.codec import default_codec
+from whoosh.codec.whoosh3 import W3Codec
+from whoosh.fields import ID, KEYWORD, TEXT, Schema
+from whoosh.filedb.filestore import RamStorage
+from whoosh.reading import TermNotFound
+from whoosh.support.bloom import BloomFilter, _optimal_num_bits, _optimal_num_hashes
+from whoosh.util.testing import TempIndex, TempStorage
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+
+def b(s):
+    return s.encode("latin-1")
+
+
+def _make_codec(**kwargs):
+    st = RamStorage()
+    codec = default_codec(**kwargs)
+    seg = codec.new_segment(st, "test")
+    return st, codec, seg
+
+
+# ===========================================================================
+# Unit tests for BloomFilter class
+# ===========================================================================
+
+
+class TestBloomFilterUnit:
+    """Pure unit tests for the BloomFilter data structure."""
+
+    def test_basic_add_and_contains(self):
+        bf = BloomFilter(expected_items=100, false_positive_rate=0.01)
+        bf.add(b"hello")
+        bf.add(b"world")
+
+        assert b"hello" in bf
+        assert b"world" in bf
+        assert b"missing" not in bf
+
+    def test_no_false_negatives(self):
+        """Items added must always be found (no false negatives)."""
+        items = [f"term_{i}".encode() for i in range(500)]
+        bf = BloomFilter(expected_items=500, false_positive_rate=0.01)
+        for item in items:
+            bf.add(item)
+        for item in items:
+            assert item in bf, f"{item!r} should be in the Bloom filter"
+
+    def test_false_positive_rate(self):
+        """False positive rate should be within expected bounds."""
+        n = 1000
+        bf = BloomFilter(expected_items=n, false_positive_rate=0.05)
+        for i in range(n):
+            bf.add(f"item_{i}".encode())
+
+        # Test with items NOT added
+        false_positives = 0
+        test_count = 10000
+        for i in range(n, n + test_count):
+            if f"item_{i}".encode() in bf:
+                false_positives += 1
+
+        fp_rate = false_positives / test_count
+        # Allow 3x the target rate as tolerance for randomness
+        assert fp_rate < 0.15, (
+            f"False positive rate {fp_rate:.3f} is too high (expected < 0.15)"
+        )
+
+    def test_empty_filter(self):
+        bf = BloomFilter(expected_items=100)
+        assert b"anything" not in bf
+        assert bf.count == 0
+
+    def test_string_keys(self):
+        """String keys should be automatically encoded to UTF-8."""
+        bf = BloomFilter(expected_items=100)
+        bf.add("café")
+        assert "café" in bf
+        assert "café".encode("utf-8") in bf
+
+    def test_count(self):
+        bf = BloomFilter(expected_items=100)
+        assert bf.count == 0
+        bf.add(b"one")
+        assert bf.count == 1
+        bf.add(b"two")
+        assert bf.count == 2
+
+    def test_properties(self):
+        bf = BloomFilter(expected_items=1000, false_positive_rate=0.01)
+        assert bf.num_bits > 0
+        assert bf.num_hashes > 0
+        assert bf.size_bytes == (bf.num_bits + 7) // 8
+
+    def test_estimated_false_positive_rate(self):
+        bf = BloomFilter(expected_items=1000, false_positive_rate=0.01)
+        assert bf.estimated_false_positive_rate() == 0.0  # Empty filter
+        for i in range(100):
+            bf.add(f"item_{i}".encode())
+        rate = bf.estimated_false_positive_rate()
+        assert 0.0 < rate < 1.0
+
+    def test_repr(self):
+        bf = BloomFilter(expected_items=100)
+        r = repr(bf)
+        assert "BloomFilter" in r
+        assert "num_bits" in r
+
+
+class TestBloomFilterSerialization:
+    """Tests for Bloom filter serialization / deserialization."""
+
+    def test_roundtrip_bytes(self):
+        bf = BloomFilter(expected_items=500, false_positive_rate=0.01)
+        items = [f"key_{i}".encode() for i in range(200)]
+        for item in items:
+            bf.add(item)
+
+        data = bf.to_bytes()
+        bf2 = BloomFilter.from_bytes(data)
+
+        # All items should still be found
+        for item in items:
+            assert item in bf2
+        # Non-existent items should (usually) not be found
+        assert b"never_added_xyz" not in bf2
+
+    def test_serialized_parameters_match(self):
+        bf = BloomFilter(expected_items=500, false_positive_rate=0.01)
+        bf.add(b"test")
+        data = bf.to_bytes()
+        bf2 = BloomFilter.from_bytes(data)
+        assert bf2.num_bits == bf.num_bits
+        assert bf2.num_hashes == bf.num_hashes
+        assert bf2.size_bytes == bf.size_bytes
+
+    def test_invalid_magic(self):
+        with pytest.raises(ValueError, match="Invalid Bloom filter magic"):
+            BloomFilter.from_bytes(b"XXXX" + b"\x00" * 20)
+
+    def test_truncated_data(self):
+        bf = BloomFilter(expected_items=100)
+        bf.add(b"test")
+        data = bf.to_bytes()
+        with pytest.raises(ValueError):
+            BloomFilter.from_bytes(data[:5])
+
+    def test_data_too_short(self):
+        with pytest.raises(ValueError, match="too short"):
+            BloomFilter.from_bytes(b"BL")
+
+
+class TestBloomFilterMerge:
+    """Tests for merging two Bloom filters."""
+
+    def test_merge(self):
+        bf1 = BloomFilter(expected_items=100, false_positive_rate=0.01)
+        bf2 = BloomFilter(expected_items=100, false_positive_rate=0.01)
+        bf1.add(b"alpha")
+        bf2.add(b"beta")
+
+        bf1.merge(bf2)
+        assert b"alpha" in bf1
+        assert b"beta" in bf1
+
+    def test_merge_mismatched_sizes(self):
+        bf1 = BloomFilter(num_bits=128, num_hashes=3)
+        bf2 = BloomFilter(num_bits=256, num_hashes=3)
+        with pytest.raises(ValueError, match="num_bits differ"):
+            bf1.merge(bf2)
+
+    def test_merge_mismatched_hashes(self):
+        bf1 = BloomFilter(num_bits=128, num_hashes=3)
+        bf2 = BloomFilter(num_bits=128, num_hashes=5)
+        with pytest.raises(ValueError, match="num_hashes differ"):
+            bf1.merge(bf2)
+
+
+class TestBloomFilterOptimalParams:
+    """Tests for optimal parameter calculations."""
+
+    def test_optimal_num_bits(self):
+        m = _optimal_num_bits(1000, 0.01)
+        # For n=1000, p=0.01: m ≈ 9585
+        assert 9000 < m < 10000
+
+    def test_optimal_num_bits_edge_cases(self):
+        assert _optimal_num_bits(0, 0.01) == 64  # Minimum
+        assert _optimal_num_bits(-1, 0.01) == 64
+
+    def test_optimal_num_hashes(self):
+        k = _optimal_num_hashes(9585, 1000)
+        # Optimal k ≈ 6.64 -> ceil = 7
+        assert 5 <= k <= 8
+
+    def test_optimal_num_hashes_edge(self):
+        assert _optimal_num_hashes(100, 0) == 1  # Minimum
+
+
+# ===========================================================================
+# Integration tests: W3Codec with Bloom filters
+# ===========================================================================
+
+
+class TestBloomCodecIntegration:
+    """Tests for Bloom filter integration with the W3Codec writer/reader."""
+
+    def test_bloom_file_created(self):
+        """Writer should create a .blm file when Bloom is enabled."""
+        st = RamStorage()
+        codec = W3Codec(bloom_enabled=True)
+        seg = codec.new_segment(st, "test")
+
+        fieldobj = fields.TEXT()
+        tw = codec.field_writer(st, seg)
+        tw.start_field("content", fieldobj)
+        tw.start_term(b"hello")
+        tw.add(0, 1.0, b"", 3)
+        tw.finish_term()
+        tw.start_term(b"world")
+        tw.add(1, 1.0, b"", 3)
+        tw.finish_term()
+        tw.finish_field()
+        tw.close()
+
+        blmname = seg.make_filename(W3Codec.BLOOM_EXT)
+        assert st.file_exists(blmname), "Bloom filter file should exist"
+        assert st.file_length(blmname) > 0, "Bloom filter file should not be empty"
+
+    def test_bloom_file_not_created_when_disabled(self):
+        """No .blm file when Bloom is disabled."""
+        st = RamStorage()
+        codec = W3Codec(bloom_enabled=False)
+        seg = codec.new_segment(st, "test")
+
+        fieldobj = fields.TEXT()
+        tw = codec.field_writer(st, seg)
+        tw.start_field("content", fieldobj)
+        tw.start_term(b"hello")
+        tw.add(0, 1.0, b"", 3)
+        tw.finish_term()
+        tw.finish_field()
+        tw.close()
+
+        blmname = seg.make_filename(W3Codec.BLOOM_EXT)
+        assert not st.file_exists(blmname), "No Bloom file when disabled"
+
+    def test_negative_lookup_via_bloom(self):
+        """Terms not in the index should be quickly rejected by the Bloom filter."""
+        st = RamStorage()
+        codec = W3Codec(bloom_enabled=True, bloom_false_positive_rate=0.001)
+        seg = codec.new_segment(st, "test")
+
+        fieldobj = fields.TEXT()
+        tw = codec.field_writer(st, seg)
+        tw.start_field("content", fieldobj)
+        for i in range(100):
+            tw.start_term(f"term{i}".encode())
+            tw.add(i, 1.0, b"", 3)
+            tw.finish_term()
+        tw.finish_field()
+        tw.close()
+
+        tr = codec.terms_reader(st, seg)
+        # Existing terms should be found
+        for i in range(100):
+            assert ("content", f"term{i}".encode()) in tr
+
+        # Non-existing terms should NOT be found (no false negatives)
+        for i in range(100, 200):
+            assert ("content", f"term{i}".encode()) not in tr
+
+        tr.close()
+
+    def test_term_info_raises_for_missing_with_bloom(self):
+        """term_info should raise TermNotFound for absent terms (via Bloom)."""
+        st = RamStorage()
+        codec = W3Codec(bloom_enabled=True)
+        seg = codec.new_segment(st, "test")
+
+        fieldobj = fields.TEXT()
+        tw = codec.field_writer(st, seg)
+        tw.start_field("content", fieldobj)
+        tw.start_term(b"exists")
+        tw.add(0, 1.0, b"", 3)
+        tw.finish_term()
+        tw.finish_field()
+        tw.close()
+
+        tr = codec.terms_reader(st, seg)
+        # Should work for existing terms
+        ti = tr.term_info("content", b"exists")
+        assert ti is not None
+
+        # Should raise for missing terms
+        with pytest.raises(TermNotFound):
+            tr.term_info("content", b"does_not_exist")
+
+        tr.close()
+
+    def test_frequency_returns_zero_for_missing_with_bloom(self):
+        """frequency() should return 0 for missing terms via Bloom short-circuit."""
+        st = RamStorage()
+        codec = W3Codec(bloom_enabled=True)
+        seg = codec.new_segment(st, "test")
+
+        fieldobj = fields.TEXT()
+        tw = codec.field_writer(st, seg)
+        tw.start_field("content", fieldobj)
+        tw.start_term(b"hello")
+        tw.add(0, 2.5, b"", 3)
+        tw.finish_term()
+        tw.finish_field()
+        tw.close()
+
+        tr = codec.terms_reader(st, seg)
+        assert tr.frequency("content", b"missing_term") == 0
+        tr.close()
+
+    def test_doc_frequency_returns_zero_for_missing_with_bloom(self):
+        """doc_frequency() should return 0 for missing terms via Bloom."""
+        st = RamStorage()
+        codec = W3Codec(bloom_enabled=True)
+        seg = codec.new_segment(st, "test")
+
+        fieldobj = fields.TEXT()
+        tw = codec.field_writer(st, seg)
+        tw.start_field("content", fieldobj)
+        tw.start_term(b"hello")
+        tw.add(0, 1.0, b"", 3)
+        tw.finish_term()
+        tw.finish_field()
+        tw.close()
+
+        tr = codec.terms_reader(st, seg)
+        assert tr.doc_frequency("content", b"missing_term") == 0
+        tr.close()
+
+    def test_bloom_with_multiple_fields(self):
+        """Bloom filter should work correctly across multiple indexed fields."""
+        st = RamStorage()
+        codec = W3Codec(bloom_enabled=True)
+        seg = codec.new_segment(st, "test")
+
+        fieldobj = fields.TEXT()
+        tw = codec.field_writer(st, seg)
+
+        tw.start_field("title", fieldobj)
+        tw.start_term(b"alpha")
+        tw.add(0, 1.0, b"", 3)
+        tw.finish_term()
+        tw.finish_field()
+
+        tw.start_field("body", fieldobj)
+        tw.start_term(b"beta")
+        tw.add(0, 1.0, b"", 5)
+        tw.finish_term()
+        tw.finish_field()
+
+        tw.close()
+
+        tr = codec.terms_reader(st, seg)
+        # Each field has its own terms
+        assert ("title", b"alpha") in tr
+        assert ("body", b"beta") in tr
+        # Cross-field lookups should fail
+        assert ("title", b"beta") not in tr
+        assert ("body", b"alpha") not in tr
+        # Completely missing terms
+        assert ("title", b"gamma") not in tr
+        assert ("body", b"gamma") not in tr
+        tr.close()
+
+    def test_backward_compatibility_no_bloom_file(self):
+        """Reader should work fine if there's no .blm file (old indexes)."""
+        st = RamStorage()
+        # Write with Bloom disabled (simulates old index without .blm)
+        codec_write = W3Codec(bloom_enabled=False)
+        seg = codec_write.new_segment(st, "test")
+
+        fieldobj = fields.TEXT()
+        tw = codec_write.field_writer(st, seg)
+        tw.start_field("content", fieldobj)
+        tw.start_term(b"hello")
+        tw.add(0, 1.0, b"", 3)
+        tw.finish_term()
+        tw.finish_field()
+        tw.close()
+
+        # Read with Bloom enabled — should gracefully handle missing .blm
+        codec_read = W3Codec(bloom_enabled=True)
+        tr = codec_read.terms_reader(st, seg)
+        assert ("content", b"hello") in tr
+        assert ("content", b"missing") not in tr
+        tr.close()
+
+
+# ===========================================================================
+# End-to-end tests: full indexing and searching with Bloom filters
+# ===========================================================================
+
+
+class TestBloomEndToEnd:
+    """Full end-to-end tests with indexing and searching."""
+
+    def test_search_existing_terms(self):
+        schema = Schema(title=TEXT(stored=True), content=TEXT)
+        with TempIndex(schema, "bloom_e2e_exist") as ix:
+            with ix.writer() as w:
+                w.add_document(title="Doc One", content="alpha beta gamma")
+                w.add_document(title="Doc Two", content="delta epsilon alpha")
+
+            with ix.searcher() as s:
+                results = s.search(query.Term("content", "alpha"))
+                assert len(results) == 2
+                results = s.search(query.Term("content", "gamma"))
+                assert len(results) == 1
+
+    def test_search_nonexistent_terms(self):
+        schema = Schema(title=TEXT(stored=True), content=TEXT)
+        with TempIndex(schema, "bloom_e2e_noexist") as ix:
+            with ix.writer() as w:
+                w.add_document(title="Doc One", content="alpha beta gamma")
+
+            with ix.searcher() as s:
+                results = s.search(query.Term("content", "zzz_nonexistent"))
+                assert len(results) == 0
+                results = s.search(query.Term("content", "xyz_missing"))
+                assert len(results) == 0
+
+    def test_contains_operator(self):
+        schema = Schema(content=TEXT)
+        with TempIndex(schema, "bloom_e2e_contains") as ix:
+            with ix.writer() as w:
+                w.add_document(content="hello world foo bar")
+
+            with ix.reader() as r:
+                assert ("content", "hello") in r
+                assert ("content", "world") in r
+                assert ("content", "missing") not in r
+                assert ("content", "nonexistent") not in r
+
+    def test_doc_frequency_and_frequency(self):
+        schema = Schema(content=TEXT)
+        with TempIndex(schema, "bloom_e2e_freq") as ix:
+            with ix.writer() as w:
+                w.add_document(content="hello hello world")
+                w.add_document(content="hello foo")
+
+            with ix.reader() as r:
+                # Existing terms
+                assert r.doc_frequency("content", "hello") == 2
+                assert r.frequency("content", "hello") > 0
+                # Non-existing terms (Bloom should short-circuit)
+                assert r.doc_frequency("content", "missing") == 0
+                assert r.frequency("content", "missing") == 0
+
+    def test_multiple_segments(self):
+        """Bloom filters should work per-segment in multi-segment indexes."""
+        schema = Schema(content=TEXT(stored=True))
+        with TempIndex(schema, "bloom_e2e_multiseg") as ix:
+            # Write two separate segments
+            with ix.writer() as w:
+                w.add_document(content="alpha beta")
+            with ix.writer() as w:
+                w.add_document(content="gamma delta")
+
+            with ix.searcher() as s:
+                results = s.search(query.Term("content", "alpha"))
+                assert len(results) == 1
+                results = s.search(query.Term("content", "gamma"))
+                assert len(results) == 1
+                results = s.search(query.Term("content", "nonexistent"))
+                assert len(results) == 0
+
+    def test_index_optimization_preserves_bloom(self):
+        """After optimizing (merging segments), Bloom should still work."""
+        schema = Schema(content=TEXT(stored=True))
+        with TempIndex(schema, "bloom_e2e_optimize") as ix:
+            with ix.writer() as w:
+                w.add_document(content="alpha beta")
+            with ix.writer() as w:
+                w.add_document(content="gamma delta")
+
+            # Optimize to merge all segments
+            ix.optimize()
+
+            with ix.searcher() as s:
+                results = s.search(query.Term("content", "alpha"))
+                assert len(results) == 1
+                results = s.search(query.Term("content", "gamma"))
+                assert len(results) == 1
+                results = s.search(query.Term("content", "nonexistent"))
+                assert len(results) == 0
+
+    def test_keyword_field_with_bloom(self):
+        schema = Schema(tag=KEYWORD(stored=True, commas=True))
+        with TempIndex(schema, "bloom_e2e_kw") as ix:
+            with ix.writer() as w:
+                w.add_document(tag="python,search,index")
+                w.add_document(tag="bloom,filter,search")
+
+            with ix.searcher() as s:
+                results = s.search(query.Term("tag", "search"))
+                assert len(results) == 2
+                results = s.search(query.Term("tag", "bloom"))
+                assert len(results) == 1
+                results = s.search(query.Term("tag", "java"))
+                assert len(results) == 0
+
+    def test_id_field_with_bloom(self):
+        schema = Schema(path=ID(stored=True, unique=True), content=TEXT)
+        with TempIndex(schema, "bloom_e2e_id") as ix:
+            with ix.writer() as w:
+                w.add_document(path="/a/b", content="hello world")
+                w.add_document(path="/c/d", content="foo bar")
+
+            with ix.searcher() as s:
+                results = s.search(query.Term("path", "/a/b"))
+                assert len(results) == 1
+                results = s.search(query.Term("path", "/nonexistent"))
+                assert len(results) == 0


### PR DESCRIPTION
## What was done

Implemented Bloom filters to reduce latency on negative term lookups. When searching for a term that does not exist in the index, the engine previously had to perform expensive on-disk hash table reads before confirming the term's absence. With this change, a compact in-memory Bloom filter is checked first — if the term is definitely not present, the disk read is skipped entirely.

**Key changes:**

- **`src/whoosh/support/bloom.py`** — Standalone `BloomFilter` class with double-hashing scheme (MD5 + SHA-256), configurable false positive rate, serialization/deserialization support, and filter merging capability.
- **`src/whoosh/codec/whoosh3.py`** — Integration into the W3 codec:
  - `W3FieldWriter` collects all term keys during indexing and writes a `.blm` file on close.
  - `W3TermsReader` loads the Bloom filter on initialization and short-circuits `__contains__`, `term_info`, `frequency`, and `doc_frequency` for absent terms.
  - `W3Codec` exposes `bloom_enabled` and `bloom_false_positive_rate` parameters (enabled by default, 1% FPR).
- **`tests/test_bloom.py`** — 8 classes, 35 tests (see Tests section below).

**Design decisions:**

- Backward compatible: indexes without `.blm` files are handled gracefully (Bloom check is simply skipped).
- Per-segment filtering: each segment maintains its own Bloom filter, working naturally with multi-segment and optimized indexes.
- Zero false negatives guaranteed: the filter only avoids unnecessary disk reads, never hides existing terms.

## Tests

A new test file `tests/test_bloom.py` was added with 8 classes and 35 tests:

- **`TestBloomFilterUnit`** — standalone `BloomFilter` correctness: `add()`/`__contains__`, zero-false-negative guarantee over 500 items, false positive rate within bounds, UTF-8 key encoding, `size_bytes`, `__repr__`.
- **`TestBloomFilterSerialization`** — `to_bytes()`/`from_bytes()` round-trips; invalid magic bytes and truncated data raise `ValueError`.
- **`TestBloomFilterMerge`** — merging two filters combines their items; mismatched parameters raise `ValueError`.
- **`TestBloomFilterOptimalParams`** — `_optimal_num_bits()` and `_optimal_num_hashes()` produce correct values; edge inputs (0, -1) are handled.
- **`TestBloomCodecIntegration`** — `W3Codec` writes a `.blm` file when enabled and skips it when disabled; negative term lookups are rejected by the filter; `term_info`, `frequency`, and `doc_frequency` short-circuit for absent terms; backward compatibility when no `.blm` file exists.
- **`TestBloomEndToEnd`** — full indexing and searching across TEXT, KEYWORD, and ID fields; multi-segment indexes; segment optimization (merge) preserves the filter.

All existing tests continue to pass with no regressions.

---

## Performance

All benchmarks were executed inside Docker containers to isolate the runtime environment and eliminate host-specific variance from CPU scheduling, OS caching, and library versions.

### Methodology

- 50 total runs; first 10 (warmup) and last 10 (cooldown) discarded; 30 effective runs measured.
- Index: 500,000 documents.
- Workload: 1,000 queries per run using terms guaranteed to be absent from the index, directly targeting the negative-lookup path.
- Fixed seed (42) for reproducibility.
- Timing: `time.perf_counter_ns()` with GC disabled during measurement.

### Rationale

Whoosh already has internal term caching, which partially mitigates the cost of repeated negative lookups on the same terms. The Bloom filter provides an earlier, cheaper pre-check that runs before any cache or disk operation, allowing confirmed misses to be resolved in O(k) hash computations alone.

### Results

| Variant | Mean (ms) | Std dev (ms) | Runs |
|---|---|---|---|
| Baseline | 28.36 | 7.49 | 30 |
| Optimized | 24.98 | 5.15 | 30 |
| **Improvement** | | | **11.93%** |

![Bloom Filter benchmark comparison](https://raw.githubusercontent.com/matheusvir/eda-oss-performance/main/analysis/plots/whoosh-reloaded/whoosh_bloom_filter_comparison.png)

### Analysis

The mean improvement is 11.93%. The difference between means (3.38 ms) is smaller than the baseline standard deviation (7.49 ms), so the result does not clear the strict statistical confirmation threshold used in this study. Even so, the improvement is consistent: the optimized median is 23.60 ms vs 28.36 ms in the baseline, and the standard deviation is reduced from 7.49 ms to 5.15 ms.

The modest absolute gain compared to the TinyDB Bloom Filter reflects that Whoosh already performs internal caching, which absorbs part of the negative-lookup cost in the baseline.

**Note:** as a probabilistic data structure, exact timings will vary across runs and machines. The no-false-negative guarantee is preserved: the filter never hides an existing term. False positives (at most 1% by default) simply fall back to the normal lookup path.

### Reproducing the benchmark

The full benchmark infrastructure is available in the research repository at [matheusvir/eda-oss-performance](https://github.com/matheusvir/eda-oss-performance).

Relevant files:

- Dockerfile: [`setup/whoosh-reloaded/Dockerfile`](https://github.com/matheusvir/eda-oss-performance/blob/main/setup/whoosh-reloaded/Dockerfile)
- Baseline script: [`experiments/whoosh-reloaded/baseline_whoosh-reloaded_bloom-filter.py`](https://github.com/matheusvir/eda-oss-performance/blob/main/experiments/whoosh-reloaded/baseline_whoosh-reloaded_bloom-filter.py)
- Experiment script: [`experiments/whoosh-reloaded/experiment_whoosh-reloaded_bloom-filter.py`](https://github.com/matheusvir/eda-oss-performance/blob/main/experiments/whoosh-reloaded/experiment_whoosh-reloaded_bloom-filter.py)
- Runner script: [`experiments/whoosh-reloaded/run_bloom_filter.sh`](https://github.com/matheusvir/eda-oss-performance/blob/main/experiments/whoosh-reloaded/run_bloom_filter.sh)

To run:

```bash
# From the root of eda-oss-performance
bash experiments/whoosh-reloaded/run_bloom_filter.sh
```

The runner checks out the baseline and experiment git refs, builds a separate Docker image for each, runs both containers, and writes results to `results/whoosh-reloaded/result_whoosh-reloaded_bloom-filter.json`.

---

Feedback on the `.blm` file format, filter sizing strategy, and segment merge behavior is welcome.
