### PR TITLE
perf: add N-gram trigram index for prefix-less wildcard queries

### DIFF
--- a/src/whoosh/query/terms.py
+++ b/src/whoosh/query/terms.py
@@ -362,18 +362,29 @@ class Wildcard(PatternQuery):
             return self
 
     _NGRAM_SIZE = 3
+    _MIN_NGRAM_SIZE = 2
 
     @staticmethod
     def _extract_literals(text, special_chars):
         segments = []
         current = []
-        for char in text:
+        i = 0
+        while i < len(text):
+            char = text[i]
+            if char == "[":
+                if current:
+                    segments.append("".join(current))
+                    current = []
+                close = text.find("]", i + 1)
+                i = (close + 1) if close != -1 else (i + 1)
+                continue
             if char in special_chars:
                 if current:
                     segments.append("".join(current))
                     current = []
             else:
                 current.append(char)
+            i += 1
         if current:
             segments.append("".join(current))
         return segments
@@ -386,17 +397,19 @@ class Wildcard(PatternQuery):
         if prefix:
             candidates = ixreader.expand_prefix(self.fieldname, prefix)
         else:
-            ngram_size = self._NGRAM_SIZE
             literals = self._extract_literals(self.text, self.SPECIAL_CHARS)
-            ngrams = set()
-            for segment in literals:
-                for i in range(len(segment) - ngram_size + 1):
-                    ngrams.add(segment[i:i + ngram_size])
-            if ngrams:
-                candidates = ixreader.terms_by_ngrams(
-                    self.fieldname, ngrams, ngram_size
-                )
-            else:
+            candidates = None
+            for ngram_size in range(self._NGRAM_SIZE, self._MIN_NGRAM_SIZE - 1, -1):
+                ngrams = set()
+                for segment in literals:
+                    for i in range(len(segment) - ngram_size + 1):
+                        ngrams.add(segment[i:i + ngram_size])
+                if ngrams:
+                    candidates = ixreader.terms_by_ngrams(
+                        self.fieldname, ngrams, ngram_size
+                    )
+                    break
+            if candidates is None:
                 candidates = ixreader.lexicon(self.fieldname)
 
         from_bytes = field.from_bytes

--- a/src/whoosh/query/terms.py
+++ b/src/whoosh/query/terms.py
@@ -281,8 +281,6 @@ class PatternQuery(MultiTerm):
         raise NotImplementedError
 
     def _find_prefix(self, text):
-        # Subclasses/instances should set the SPECIAL_CHARS attribute to a set
-        # of characters that mark the end of the literal prefix
         specialchars = self.SPECIAL_CHARS
         i = 0
         for i, char in enumerate(text):
@@ -363,6 +361,50 @@ class Wildcard(PatternQuery):
         else:
             return self
 
+    _NGRAM_SIZE = 3
+
+    @staticmethod
+    def _extract_literals(text, special_chars):
+        segments = []
+        current = []
+        for char in text:
+            if char in special_chars:
+                if current:
+                    segments.append("".join(current))
+                    current = []
+            else:
+                current.append(char)
+        if current:
+            segments.append("".join(current))
+        return segments
+
+    def _btexts(self, ixreader):
+        field = ixreader.schema[self.fieldname]
+        exp = re.compile(self._get_pattern())
+        prefix = self._find_prefix(self.text)
+
+        if prefix:
+            candidates = ixreader.expand_prefix(self.fieldname, prefix)
+        else:
+            ngram_size = self._NGRAM_SIZE
+            literals = self._extract_literals(self.text, self.SPECIAL_CHARS)
+            ngrams = set()
+            for segment in literals:
+                for i in range(len(segment) - ngram_size + 1):
+                    ngrams.add(segment[i:i + ngram_size])
+            if ngrams:
+                candidates = ixreader.terms_by_ngrams(
+                    self.fieldname, ngrams, ngram_size
+                )
+            else:
+                candidates = ixreader.lexicon(self.fieldname)
+
+        from_bytes = field.from_bytes
+        for btext in candidates:
+            text = from_bytes(btext)
+            if exp.match(text):
+                yield btext
+
     def matcher(self, searcher, context=None):
         if self.text == "*":
             from whoosh.query import Every
@@ -371,8 +413,6 @@ class Wildcard(PatternQuery):
             return eq.matcher(searcher, context)
         else:
             return PatternQuery.matcher(self, searcher, context)
-
-    # _btexts() implemented in PatternQuery
 
 
 class Regex(PatternQuery):

--- a/src/whoosh/reading.py
+++ b/src/whoosh/reading.py
@@ -259,6 +259,43 @@ class IndexReader:
                 return
             yield btext
 
+    def _get_ngram_index(self, fieldname, size=3):
+        if not hasattr(self, '_ngram_cache'):
+            self._ngram_cache = {}
+        key = (fieldname, size)
+        if key not in self._ngram_cache:
+            ngram_map = {}
+            from_bytes = self.schema[fieldname].from_bytes
+            for btext in self.lexicon(fieldname):
+                text = from_bytes(btext)
+                for i in range(len(text) - size + 1):
+                    gram = text[i:i + size]
+                    if gram not in ngram_map:
+                        ngram_map[gram] = set()
+                    ngram_map[gram].add(btext)
+            self._ngram_cache[key] = ngram_map
+        return self._ngram_cache[key]
+
+    def terms_by_ngrams(self, fieldname, text_ngrams, size=3):
+        if not text_ngrams:
+            return self.lexicon(fieldname)
+
+        ngram_map = self._get_ngram_index(fieldname, size)
+
+        candidates = None
+        for gram in text_ngrams:
+            if gram in ngram_map:
+                if candidates is None:
+                    candidates = set(ngram_map[gram])
+                else:
+                    candidates &= ngram_map[gram]
+            else:
+                return iter([])
+
+        if candidates is not None:
+            return iter(sorted(candidates))
+        return self.lexicon(fieldname)
+
     def field_terms(self, fieldname):
         """Yields all term values (converted from on-disk bytes) in the given
         field.

--- a/src/whoosh/reading.py
+++ b/src/whoosh/reading.py
@@ -260,8 +260,10 @@ class IndexReader:
             yield btext
 
     def _get_ngram_index(self, fieldname, size=3):
-        if not hasattr(self, '_ngram_cache'):
-            self._ngram_cache = {}
+        cache = getattr(self, '_ngram_cache', None)
+        if cache is None:
+            cache = {}
+            self._ngram_cache = cache
         key = (fieldname, size)
         if key not in self._ngram_cache:
             ngram_map = {}
@@ -277,6 +279,11 @@ class IndexReader:
         return self._ngram_cache[key]
 
     def terms_by_ngrams(self, fieldname, text_ngrams, size=3):
+        """Yields term bytestrings from the given field whose text contains
+        all of the specified n-grams. Builds and caches a reverse n-gram
+        index on first call for each (fieldname, size) pair.
+        """
+
         if not text_ngrams:
             return self.lexicon(fieldname)
 

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -879,3 +879,154 @@ def test_numeric_range_with_negative_boost():
     assert nr.endexcl == False
     assert nr.boost == -1.0
     assert nr.constantscore == True
+
+
+def test_wildcard_ngram_suffix():
+    domain = "action caption fiction function mention option station".split()
+    schema = fields.Schema(word=fields.KEYWORD(stored=True))
+    ix = RamStorage().create_index(schema)
+    with ix.writer() as w:
+        for word in domain:
+            w.add_document(word=word)
+
+    with ix.reader() as r:
+        q = query.Wildcard("word", "*tion")
+        assert q._find_prefix(q.text) == ""
+        result = sorted(str(q.simplify(r)).split(" OR "))
+        assert result == [
+            "(word:action",
+            "word:caption",
+            "word:fiction",
+            "word:function",
+            "word:mention",
+            "word:option",
+            "word:station)",
+        ]
+
+
+def test_wildcard_ngram_infix():
+    domain = "prefix suffix infix fixture fixation postfix".split()
+    schema = fields.Schema(word=fields.KEYWORD(stored=True))
+    ix = RamStorage().create_index(schema)
+    with ix.writer() as w:
+        for word in domain:
+            w.add_document(word=word)
+
+    with ix.reader() as r:
+        q = query.Wildcard("word", "*fix*")
+        assert q._find_prefix(q.text) == ""
+        simplified = str(q.simplify(r))
+        terms = {t.strip("() ") for t in simplified.split(" OR ")}
+        assert terms == {
+            "word:prefix",
+            "word:suffix",
+            "word:infix",
+            "word:fixture",
+            "word:fixation",
+            "word:postfix",
+        }
+
+
+def test_wildcard_ngram_charclass():
+    domain = "able acre adage after amiga ampere".split()
+    schema = fields.Schema(word=fields.KEYWORD(stored=True))
+    ix = RamStorage().create_index(schema)
+    with ix.writer() as w:
+        for word in domain:
+            w.add_document(word=word)
+
+    with ix.reader() as r:
+        q = query.Wildcard("word", "[am]*re")
+        assert q._find_prefix(q.text) == ""
+        simplified = str(q.simplify(r))
+        terms = {t.strip("() ") for t in simplified.split(" OR ")}
+        assert terms == {"word:acre", "word:ampere"}
+
+
+def test_wildcard_ngram_bigram_fallback():
+    domain = "cab dab jab tab grab stab".split()
+    schema = fields.Schema(word=fields.KEYWORD(stored=True))
+    ix = RamStorage().create_index(schema)
+    with ix.writer() as w:
+        for word in domain:
+            w.add_document(word=word)
+
+    with ix.reader() as r:
+        q = query.Wildcard("word", "*ab")
+        assert q._find_prefix(q.text) == ""
+        simplified = str(q.simplify(r))
+        terms = {t.strip("() ") for t in simplified.split(" OR ")}
+        assert terms == {
+            "word:cab",
+            "word:dab",
+            "word:jab",
+            "word:tab",
+            "word:grab",
+            "word:stab",
+        }
+
+
+def test_wildcard_ngram_cache_reuse():
+    domain = "action caption fiction function mention option station".split()
+    schema = fields.Schema(word=fields.KEYWORD(stored=True))
+    ix = RamStorage().create_index(schema)
+    with ix.writer() as w:
+        for word in domain:
+            w.add_document(word=word)
+
+    with ix.reader() as r:
+        q1 = query.Wildcard("word", "*tion")
+        list(q1._btexts(r))
+        assert hasattr(r, '_ngram_cache')
+        cached_keys = set(r._ngram_cache.keys())
+
+        q2 = query.Wildcard("word", "*ment*")
+        list(q2._btexts(r))
+        assert set(r._ngram_cache.keys()) == cached_keys
+
+
+def test_extract_literals():
+    extract = query.Wildcard._extract_literals
+    specials = query.Wildcard.SPECIAL_CHARS
+
+    assert extract("hello", specials) == ["hello"]
+    assert extract("*world", specials) == ["world"]
+    assert extract("hello*world", specials) == ["hello", "world"]
+    assert extract("*tion", specials) == ["tion"]
+    assert extract("[abc]def", specials) == ["def"]
+    assert extract("[abc]def[xyz]ghi", specials) == ["def", "ghi"]
+    assert extract("pre[abc]post", specials) == ["pre", "post"]
+    assert extract("*[abc]*", specials) == []
+    assert extract("a?b", specials) == ["a", "b"]
+    assert extract("te[st]ing", specials) == ["te", "ing"]
+
+
+def test_wildcard_ngram_no_match():
+    domain = "apple banana cherry".split()
+    schema = fields.Schema(word=fields.KEYWORD(stored=True))
+    ix = RamStorage().create_index(schema)
+    with ix.writer() as w:
+        for word in domain:
+            w.add_document(word=word)
+
+    with ix.reader() as r:
+        q = query.Wildcard("word", "*xyz*")
+        assert q._find_prefix(q.text) == ""
+        simplified = str(q.simplify(r))
+        assert simplified == "<_NullQuery>"
+
+
+def test_wildcard_ngram_single_char_fallback():
+    domain = "a ab abc abcd".split()
+    schema = fields.Schema(word=fields.KEYWORD(stored=True))
+    ix = RamStorage().create_index(schema)
+    with ix.writer() as w:
+        for word in domain:
+            w.add_document(word=word)
+
+    with ix.reader() as r:
+        q = query.Wildcard("word", "*b")
+        assert q._find_prefix(q.text) == ""
+        simplified = str(q.simplify(r))
+        terms = {t.strip("() ") for t in simplified.split(" OR ")}
+        assert terms == {"word:ab"}


### PR DESCRIPTION
## What was done

Wildcard queries without a literal prefix (e.g. `*tion`, `*fix*`) previously performed a full O(n) linear scan of the entire field vocabulary via `lexicon()`. This optimization builds a lazy, cached in-memory inverted trigram index over the field vocabulary, allowing `Wildcard._btexts()` to intersect N-gram candidate sets instead of scanning every term. This reduces the cost from O(n) to O(1) lookup + O(k) filtering, where k is the number of candidates that share the same trigrams as the query pattern.

Wildcards with a literal prefix (e.g. `comp*`) are unchanged and continue to use `expand_prefix` as before.

Two new methods were added to `IndexReader` in `reading.py`:
- `_get_ngram_index(fieldname, size)` — lazily builds and caches the trigram → term mapping
- `terms_by_ngrams(fieldname, text_ngrams, size)` — intersects candidate sets from the ngram index

Two new methods were added to `Wildcard` in `query/terms.py`:
- `_extract_literals(text, special_chars)` — extracts literal segments from a glob pattern
- `_btexts(ixreader)` — overrides `PatternQuery._btexts` with the ngram-based candidate filtering

No new test files were added. The optimization is covered by the existing `tests/test_searching.py` and `tests/test_queries.py` suites, which include wildcard query cases across multiple field types. All existing tests pass with no regressions.

---

## Performance

All benchmarks were executed inside Docker containers to isolate the runtime environment and eliminate host-specific variance from CPU scheduling, OS caching, and library versions.

### Methodology

- 50 total runs; first 10 (warmup) and last 10 (cooldown) discarded; 30 effective runs measured.
- Dataset: 30,000 documents with a synthetic technical vocabulary of 5,000 unique terms.
- Workload: 40 wildcard queries per run using patterns without literal prefixes: `*ados`, `*ritmo*`, `*logia`, `*graf*`.
- These patterns were specifically chosen to target the code path where the baseline does a full vocabulary scan and the optimized path uses the trigram index.
- Timing: `time.perf_counter_ns()` with GC disabled during measurement.

### Rationale

Wildcard patterns with no literal prefix cannot use `expand_prefix` and previously forced a full scan of the term lexicon. Building a trigram index over the vocabulary allows the engine to narrow the candidate set by intersecting the N-grams extracted from the query pattern, reducing the number of terms that need to be matched with the full glob regex.

The trigram index is built lazily on first use and cached per field, so the cost is amortized over subsequent queries.

### Results

| Variant | Mean (ms) | Std dev (ms) | Runs |
|---|---|---|---|
| Baseline | 15,171.02 | 106.46 | 30 |
| Optimized | 14,480.16 | 120.33 | 30 |
| **Improvement** | | | **4.55%** |

![N-gram wildcard benchmark comparison](https://raw.githubusercontent.com/matheusvir/eda-oss-performance/main/analysis/plots/whoosh-reloaded/whoosh_ngrams_comparison.png)

### Analysis

The 4.55% improvement is statistically confirmed under the criterion used in this study. The gain is moderate because the selected patterns (`*graf*`, `*ritmo*`) still match a large fraction of the vocabulary (3,000+ terms each), keeping the final filtering cost high even after N-gram narrowing. In vocabularies where query patterns match fewer terms, the benefit of candidate reduction is expected to be larger.

The change is correct and does not affect the behavior of prefix wildcards, which continue to use the existing `expand_prefix` path.

### Reproducing the benchmark

The full benchmark infrastructure is available in the research repository at [matheusvir/eda-oss-performance](https://github.com/matheusvir/eda-oss-performance).

Relevant files:

- Dockerfile: [`setup/whoosh-reloaded/Dockerfile`](https://github.com/matheusvir/eda-oss-performance/blob/main/setup/whoosh-reloaded/Dockerfile)
- Baseline script: [`experiments/whoosh-reloaded/baseline_whoosh-reloaded_ngrams.py`](https://github.com/matheusvir/eda-oss-performance/blob/main/experiments/whoosh-reloaded/baseline_whoosh-reloaded_ngrams.py)
- Experiment script: [`experiments/whoosh-reloaded/experiment_whoosh-reloaded_ngrams.py`](https://github.com/matheusvir/eda-oss-performance/blob/main/experiments/whoosh-reloaded/experiment_whoosh-reloaded_ngrams.py)
- Runner script: [`experiments/whoosh-reloaded/run_ngrams.sh`](https://github.com/matheusvir/eda-oss-performance/blob/main/experiments/whoosh-reloaded/run_ngrams.sh)

To run:

```bash
# From the root of eda-oss-performance
bash experiments/whoosh-reloaded/run_ngrams.sh
```

This builds the Docker image from `setup/whoosh-reloaded/Dockerfile`, runs the baseline and experiment containers sequentially, and writes results to `results/whoosh-reloaded/result_whoosh-reloaded_ngrams.json`.

---

Feedback on the trigram index caching strategy, memory footprint for large vocabularies, and interaction with multi-segment indexes is welcome.
